### PR TITLE
WIP : Addition of livelinessCheck

### DIFF
--- a/src/main/java/io/appform/dropwizard/discovery/bundle/Constants.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/Constants.java
@@ -29,4 +29,8 @@ public class Constants {
     public static final int DEFAULT_PORT = -1;
     public static final int DEFAULT_DW_CHECK_INTERVAL = 15;
     public static final int DEFAULT_RETRY_CONN_INTERVAL = 5000;
+    public static final double DEFAULT_LIVELINESS_THRESHOLD = 1D;
+    public static final int DEFAULT_INITIAL_DELAY = 5;
+    public static final int DEFAULT_DW_STALENESS_SECONDS = 30;
+    public static final String THREAD_UTIL_GAUGE = "org.eclipse.jetty.util.thread.QueuedThreadPool.dw.utilization-max";
 }

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryConfiguration.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryConfiguration.java
@@ -118,9 +118,7 @@ public class ServiceDiscoveryConfiguration {
                                        ? Constants.DEFAULT_DW_CHECK_INTERVAL
                                        : dropwizardCheckInterval;
         this.dropwizardCheckStaleness = dropwizardCheckStaleness;
-        this.livelinessCheck = null != livelinessCheck
-                                        ? livelinessCheck
-                                        : LivelinessCheck.builder().build();
+        this.livelinessCheck = livelinessCheck;
     }
 
 }

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryConfiguration.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryConfiguration.java
@@ -78,8 +78,6 @@ public class ServiceDiscoveryConfiguration {
 
     private int dropwizardCheckStaleness;
 
-    private boolean disableLivelinessCheck = true;
-
     @Valid
     private LivelinessCheck livelinessCheck;
 
@@ -97,7 +95,6 @@ public class ServiceDiscoveryConfiguration {
             boolean initialRotationStatus,
             int dropwizardCheckInterval,
             int dropwizardCheckStaleness,
-            boolean disableLivelinessCheck,
             LivelinessCheck livelinessCheck) {
         this.namespace = Strings.isNullOrEmpty(namespace)
                          ? Constants.DEFAULT_NAMESPACE
@@ -121,7 +118,6 @@ public class ServiceDiscoveryConfiguration {
                                        ? Constants.DEFAULT_DW_CHECK_INTERVAL
                                        : dropwizardCheckInterval;
         this.dropwizardCheckStaleness = dropwizardCheckStaleness;
-        this.disableLivelinessCheck = disableLivelinessCheck;
         this.livelinessCheck = null != livelinessCheck
                                         ? livelinessCheck
                                         : LivelinessCheck.builder().build();

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryConfiguration.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryConfiguration.java
@@ -17,13 +17,19 @@
 
 package io.appform.dropwizard.discovery.bundle;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import io.appform.dropwizard.discovery.bundle.config.LivelinessCheck;
 import lombok.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import java.util.List;
 
 /**
  * Ranger configuration.
@@ -72,6 +78,11 @@ public class ServiceDiscoveryConfiguration {
 
     private int dropwizardCheckStaleness;
 
+    private boolean disableLivelinessCheck = true;
+
+    @Valid
+    private LivelinessCheck livelinessCheck;
+
     @Builder
     public ServiceDiscoveryConfiguration(
             String namespace,
@@ -85,7 +96,9 @@ public class ServiceDiscoveryConfiguration {
             long initialDelaySeconds,
             boolean initialRotationStatus,
             int dropwizardCheckInterval,
-            int dropwizardCheckStaleness) {
+            int dropwizardCheckStaleness,
+            boolean disableLivelinessCheck,
+            LivelinessCheck livelinessCheck) {
         this.namespace = Strings.isNullOrEmpty(namespace)
                          ? Constants.DEFAULT_NAMESPACE
                          : namespace;
@@ -108,5 +121,10 @@ public class ServiceDiscoveryConfiguration {
                                        ? Constants.DEFAULT_DW_CHECK_INTERVAL
                                        : dropwizardCheckInterval;
         this.dropwizardCheckStaleness = dropwizardCheckStaleness;
+        this.disableLivelinessCheck = disableLivelinessCheck;
+        this.livelinessCheck = null != livelinessCheck
+                                        ? livelinessCheck
+                                        : LivelinessCheck.builder().build();
     }
+
 }

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/config/LivelinessCheck.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/config/LivelinessCheck.java
@@ -1,0 +1,23 @@
+package io.appform.dropwizard.discovery.bundle.config;
+
+import io.appform.dropwizard.discovery.bundle.Constants;
+import lombok.Builder;
+import lombok.Value;
+import lombok.extern.jackson.Jacksonized;
+
+import javax.validation.constraints.Min;
+
+@Value
+@Builder
+@Jacksonized
+public class LivelinessCheck {
+    @Builder.Default
+    int initialDelayForMonitor = Constants.DEFAULT_INITIAL_DELAY;
+    @Builder.Default
+    int checkInterval = Constants.DEFAULT_DW_CHECK_INTERVAL;
+    @Builder.Default
+    int stalesnessInterval = Constants.DEFAULT_DW_STALENESS_SECONDS;
+    @Min(0)
+    @Builder.Default
+    double unhealthyThreshold = Constants.DEFAULT_LIVELINESS_THRESHOLD;
+}

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/healthchecks/InitialDelayChecker.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/healthchecks/InitialDelayChecker.java
@@ -28,7 +28,6 @@ import io.appform.ranger.core.healthcheck.HealthcheckStatus;
 public class InitialDelayChecker implements Healthcheck {
     private final long validRegistrationTime;
 
-
     public InitialDelayChecker(long initialDelaySeconds) {
         validRegistrationTime = System.currentTimeMillis() + initialDelaySeconds * 1000;
     }

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/monitors/DropwizardMetricComparator.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/monitors/DropwizardMetricComparator.java
@@ -21,7 +21,6 @@ import javax.inject.Singleton;
 @Slf4j
 public class DropwizardMetricComparator extends IsolatedHealthMonitor<HealthcheckStatus> {
 
-
     private final String metricName;
     private final MetricRegistry metricRegistry;
     private final double unhealthyThreshold;

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/monitors/DropwizardMetricComparator.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/monitors/DropwizardMetricComparator.java
@@ -1,0 +1,59 @@
+package io.appform.dropwizard.discovery.bundle.monitors;
+
+import com.codahale.metrics.MetricRegistry;
+import io.appform.ranger.core.healthcheck.HealthcheckStatus;
+import io.appform.ranger.core.healthservice.TimeEntity;
+import io.appform.ranger.core.healthservice.monitor.IsolatedHealthMonitor;
+import io.dropwizard.setup.Environment;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import lombok.val;
+import lombok.var;
+
+import javax.inject.Singleton;
+
+
+/*
+    Users can use this metricComparator class, so long as the value to be compared is a number and can
+    build multiple isolatedHealthMonitors as required.
+ */
+@Singleton
+@Slf4j
+public class DropwizardMetricComparator extends IsolatedHealthMonitor<HealthcheckStatus> {
+
+
+    private final String metricName;
+    private final MetricRegistry metricRegistry;
+    private final double unhealthyThreshold;
+
+    @Builder
+    public DropwizardMetricComparator(TimeEntity runInterval,
+                                      long stalenessAllowedInMillis,
+                                      Environment environment,
+                                      String metricName,
+                                      double unhealthyThreshold) {
+        super(String.format("/%s-%s", "dw-metric-monitor", metricName), runInterval,  stalenessAllowedInMillis);
+
+        this.metricRegistry = environment.metrics();
+        this.metricName = metricName;
+        this.unhealthyThreshold = unhealthyThreshold;
+    }
+
+
+    @Override
+    public HealthcheckStatus monitor() {
+        var healthcheckStatus = HealthcheckStatus.healthy;
+        val gauge = metricRegistry.getGauges().get(metricName);
+        if(null != gauge && null != gauge.getValue()){
+            try{
+                double tUtilization = Double.parseDouble(gauge.getValue().toString());
+                if(tUtilization >= unhealthyThreshold){
+                    healthcheckStatus = HealthcheckStatus.unhealthy;
+                }
+            }catch (Exception e){
+                log.error("There is an exception {} while trying to fetch the metric for {}", e, metricName);
+            }
+        }
+        return healthcheckStatus;
+    }
+}

--- a/src/test/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryBundleLivelinessCheckTest.java
+++ b/src/test/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryBundleLivelinessCheckTest.java
@@ -1,20 +1,3 @@
-/*
- * Copyright (c) 2019 Santanu Sinha <santanu.sinha@gmail.com>
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- *
- */
-
 package io.appform.dropwizard.discovery.bundle;
 
 import ch.qos.logback.classic.Level;
@@ -25,6 +8,7 @@ import com.codahale.metrics.health.HealthCheckRegistry;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.appform.dropwizard.discovery.bundle.config.LivelinessCheck;
 import io.appform.ranger.core.healthcheck.HealthcheckStatus;
+import io.appform.ranger.core.healthservice.monitor.IsolatedHealthMonitor;
 import io.dropwizard.Configuration;
 import io.dropwizard.jersey.DropwizardResourceConfig;
 import io.dropwizard.jersey.setup.JerseyEnvironment;
@@ -40,6 +24,8 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.slf4j.LoggerFactory;
 
 import java.util.SortedMap;
@@ -48,10 +34,12 @@ import static io.appform.dropwizard.discovery.bundle.TestUtils.assertNodeAbsence
 import static io.appform.dropwizard.discovery.bundle.TestUtils.assertNodePresence;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.when;
 
-
+@SuppressWarnings("ALL")
 @Slf4j
-class ServiceDiscoveryBundleTest {
+public class ServiceDiscoveryBundleLivelinessCheckTest {
+
 
     private final HealthCheckRegistry healthChecks = mock(HealthCheckRegistry.class);
     private final JerseyEnvironment jerseyEnvironment = mock(JerseyEnvironment.class);
@@ -60,6 +48,9 @@ class ServiceDiscoveryBundleTest {
     private final Environment environment = mock(Environment.class);
     private final Bootstrap<?> bootstrap = mock(Bootstrap.class);
     private final Configuration configuration = mock(Configuration.class);
+    private final SortedMap<String, Gauge> gauges = mock(SortedMap.class);
+    private final Gauge gauge = mock(Gauge.class);
+    private String gaugeRatio = "0.5";
 
     static {
         val root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
@@ -82,10 +73,17 @@ class ServiceDiscoveryBundleTest {
 
     private ServiceDiscoveryConfiguration serviceDiscoveryConfiguration;
     private final TestingCluster testingCluster = new TestingCluster(1);
-    private HealthcheckStatus status = HealthcheckStatus.healthy;
 
     @BeforeEach
     void setup() throws Exception {
+        when(gauge.getValue()).thenAnswer(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocationOnMock) throws Throwable {
+                return gaugeRatio;
+            }
+        });
+        when(gauges.get(Constants.THREAD_UTIL_GAUGE)).thenReturn(gauge);
+        when(metricRegistry.getGauges()).thenReturn(gauges);
         when(environment.metrics()).thenReturn(metricRegistry);
         when(jerseyEnvironment.getResourceConfig()).thenReturn(new DropwizardResourceConfig());
         when(environment.jersey()).thenReturn(jerseyEnvironment);
@@ -97,22 +95,30 @@ class ServiceDiscoveryBundleTest {
         when(environment.admin()).thenReturn(adminEnvironment);
 
         testingCluster.start();
+
+        val livelinessCheck = LivelinessCheck.builder()
+                .unhealthyThreshold(1)
+                .initialDelayForMonitor(2)
+                .checkInterval(2)
+                .stalesnessInterval(2)
+                .build();
         serviceDiscoveryConfiguration = ServiceDiscoveryConfiguration.builder()
-                                    .zookeeper(testingCluster.getConnectString())
-                                    .namespace("test")
-                                    .environment("testing")
-                                    .connectionRetryIntervalMillis(5000)
-                                    .publishedHost("TestHost")
-                                    .publishedPort(8021)
-                                    .initialRotationStatus(true)
-                                    .build();
+                .zookeeper(testingCluster.getConnectString())
+                .namespace("test")
+                .environment("testing")
+                .connectionRetryIntervalMillis(5000)
+                .publishedHost("TestHost")
+                .publishedPort(8021)
+                .initialRotationStatus(true)
+                .livelinessCheck(livelinessCheck)
+                .build();
         bundle.initialize(bootstrap);
         bundle.run(configuration, environment);
         bundle.getServerStatus().markStarted();
         for (LifeCycle lifeCycle : lifecycleEnvironment.getManagedObjects()){
             lifeCycle.start();
         }
-        bundle.registerHealthcheck(() -> status);
+        bundle.getHealthMonitors().forEach(IsolatedHealthMonitor::disable);
     }
 
     @AfterEach
@@ -134,7 +140,7 @@ class ServiceDiscoveryBundleTest {
         Assertions.assertEquals("testing", info.getNodeData().getEnvironment());
         Assertions.assertEquals("TestHost", info.getHost());
         Assertions.assertEquals(8021, info.getPort());
-        status = HealthcheckStatus.unhealthy;
+        gaugeRatio = "1.0";
         assertNodeAbsence(bundle);
     }
 }


### PR DESCRIPTION
A livelinessCheckMonitor has been added to dw-servicediscovery-bundle. The initial idea was to not add a livelinessConfiguration but take in list of comparators, (gauge value and thresholds), but other than threadPool utilization and possibly heap usage everything else seemed redundant, so in fact defined a livelinessCheck. 

It could be a composite check in the future should we wish it to be. At the moment it is a simple comparator check with the metric dw-utilization-max. 

A dropwizardMetricComparator has been added to perform the comparator checks atop any gauge attribute required. Tests have been written as well. 

This is WIP, because a release version for ranger is awaited before the WIP is removed.