### PR TITLE
Upgrade failsafe and other  packages.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,18 +109,18 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <dropwizard.version>2.0.28</dropwizard.version>
-        <lombok.version>1.18.22</lombok.version>
+        <lombok.version>1.18.24</lombok.version>
         <guava.version>30.1.1-jre</guava.version>
         <junit.version>5.8.2</junit.version>
         <ranger.version>1.0-RC9</ranger.version>
         <curator.version>4.2.0</curator.version>
-        <failsafe.version>3.1.0</failsafe.version>
+        <failsafe.version>3.2.4</failsafe.version>
         <curator.version>5.1.0</curator.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
         <mockito.version>4.2.0</mockito.version>
         <sonar.organization>appform-io</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <awaitility.version>4.1.1</awaitility.version>
+        <awaitility.version>4.2.0</awaitility.version>
         <logback.version>1.2.10</logback.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.dropwizard.discovery</groupId>
     <artifactId>dropwizard-service-discovery</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.28-2.RC6</version>
+    <version>2.0.28-2.RC7</version>
 
     <name>Dropwizard Service Discovery</name>
     <url>https://github.com/santanusinha/dropwizard-service-discovery</url>

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/id/IdGenerator.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/id/IdGenerator.java
@@ -48,7 +48,7 @@ public class IdGenerator {
     private static final CollisionChecker COLLISION_CHECKER = new CollisionChecker();
     private static final RetryPolicy<GenerationResult> RETRY_POLICY = RetryPolicy.<GenerationResult>builder()
             .withMaxAttempts(readRetryCount())
-            .handleIf((Predicate<Throwable>) throwable -> true)
+            .handleIf(throwable -> true)
             .handleResultIf(Objects::isNull)
             .handleResultIf(generationResult -> generationResult.getState() == IdValidationState.INVALID_RETRYABLE)
             .onRetry(event -> {


### PR DESCRIPTION
There are API changes in failsafe in 3.2.1 that make policy builders use CheckedPredicate instead of Predicate. As a result, projects which use new versions of failsafe fail to run with service-discovery-bundle.