### PR TITLE
curator started inline

### DIFF
--- a/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryBundle.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/ServiceDiscoveryBundle.java
@@ -133,6 +133,7 @@ public abstract class ServiceDiscoveryBundle<T extends Configuration> implements
                 .namespace(namespace)
                 .retryPolicy(new RetryForever(serviceDiscoveryConfiguration.getConnectionRetryIntervalMillis()))
                 .build();
+        curator.start();
         serviceProvider = buildServiceProvider(environment, objectMapper, namespace, serviceName, hostname, port,
                 portScheme);
         serviceDiscoveryClient = buildDiscoveryClient(environment, namespace, serviceName, initialCriteria,
@@ -292,7 +293,6 @@ public abstract class ServiceDiscoveryBundle<T extends Configuration> implements
         @Override
         public void start() {
             log.debug("Starting the discovery manager");
-            curator.start();
             serviceProvider.start();
             serviceDiscoveryClient.start();
             val nodeIdManager = new NodeIdManager(curator, serviceName);


### PR DESCRIPTION
From application we usually use this same curator in http-discovery (ServiceEndpointProviderFactory). With rangerhub we start the hub inline and wait for it to be ready. This curator should be started inline, so that it is ready when we initialize rangerhub client. 