### PR TITLE
Fix for child envs discovery 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [2.0.28-11]
+- Fixed hierarchical environment aware shard selector  : If a service  is deployed with environment :  env.x.y.z then it should be able to discover other services  present in enviroment -  [env , env.x , env.x.y, env.x.y.z ]
 
 ## [2.0.28-10]
 - Updated ranger version

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Provides service discovery to dropwizard services. It uses [Ranger](https://gith
 <dependency>
     <groupId>io.appform.dropwizard.discovery</groupId>
     <artifactId>dropwizard-service-discovery-bundle</artifactId>
-    <version>2.0.28-10</version>
+    <version>2.0.28-11</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>io.appform.dropwizard.discovery</groupId>
     <artifactId>dropwizard-service-discovery</artifactId>
     <packaging>jar</packaging>
-    <version>2.0.28-10</version>
+    <version>2.0.28-11</version>
 
     <name>Dropwizard Service Discovery</name>
     <url>https://github.com/santanusinha/dropwizard-service-discovery</url>

--- a/src/main/java/io/appform/dropwizard/discovery/bundle/selectors/HierarchicalEnvironmentAwareShardSelector.java
+++ b/src/main/java/io/appform/dropwizard/discovery/bundle/selectors/HierarchicalEnvironmentAwareShardSelector.java
@@ -112,7 +112,7 @@ public class HierarchicalEnvironmentAwareShardSelector implements ShardSelector<
                 }
                 log.debug("Effective environment for discovery is {}", remainingEnvironment);
                 val shardInfo = new IterableEnvironment(remainingEnvironment, separator);
-                val sepIndex = remainingEnvironment.indexOf(this.separator);
+                val sepIndex = remainingEnvironment.lastIndexOf(this.separator);
                 remainingEnvironment = sepIndex < 0
                                        ? ""
                                        : remainingEnvironment.substring(0, sepIndex);

--- a/src/test/java/io/appform/dropwizard/discovery/bundle/selectors/HierarchicalEnvironmentAwareShardSelectorTest.java
+++ b/src/test/java/io/appform/dropwizard/discovery/bundle/selectors/HierarchicalEnvironmentAwareShardSelectorTest.java
@@ -21,11 +21,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.doReturn;
 
 import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.ListMultimap;
 import io.appform.ranger.common.server.ShardInfo;
 import io.appform.ranger.core.finder.serviceregistry.MapBasedServiceRegistry;
 import io.appform.ranger.core.healthcheck.HealthcheckStatus;
 import io.appform.ranger.core.model.Service;
 import io.appform.ranger.core.model.ServiceNode;
+import java.util.List;
 import java.util.UUID;
 import lombok.val;
 import org.junit.jupiter.api.BeforeEach;
@@ -146,5 +148,65 @@ class HierarchicalEnvironmentAwareShardSelectorTest {
         assertEquals(1, nodes.size());
         assertEquals("host2", nodes.get(0).getHost());
         assertEquals(9999, nodes.get(0).getPort());
+    }
+
+    @Test
+    void testChildNodesAvailableForParentEnv() {
+        val serviceName = UUID.randomUUID().toString();
+        val service = Mockito.mock(Service.class);
+        doReturn(serviceName).when(service).getServiceName();
+        doReturn(service).when(serviceRegistry).getService();
+
+        // service in env: x.y.z should be able to discover service in env: x
+        ListMultimap<ShardInfo, ServiceNode<ShardInfo>> serviceNodes = ArrayListMultimap.create();
+        serviceNodes.put(
+                ShardInfo.builder().environment("x").build(),
+                new ServiceNode<>("host1",
+                        8888,
+                        ShardInfo.builder().environment("x").build(),
+                        HealthcheckStatus.healthy,
+                        System.currentTimeMillis(),
+                        "http"));
+        doReturn(serviceNodes).when(serviceRegistry).nodes();
+
+        List<ServiceNode<ShardInfo>> nodes = selector("x.y.z").nodes(null, serviceRegistry);
+        assertEquals(1, nodes.size());
+        assertEquals("host1", nodes.get(0).getHost());
+        assertEquals(8888, nodes.get(0).getPort());
+
+        // service in env: x.y.z should be able to discover service in env: x.y
+        serviceNodes = ArrayListMultimap.create();
+        serviceNodes.put(
+                ShardInfo.builder().environment("x.y").build(),
+                new ServiceNode<>("host2",
+                        9999,
+                        ShardInfo.builder().environment("x.y").build(),
+                        HealthcheckStatus.healthy,
+                        System.currentTimeMillis(),
+                        "http"));
+        doReturn(serviceNodes).when(serviceRegistry).nodes();
+
+        nodes = selector("x.y.z").nodes(null, serviceRegistry);
+        assertEquals(1, nodes.size());
+        assertEquals("host2", nodes.get(0).getHost());
+        assertEquals(9999, nodes.get(0).getPort());
+
+        // service in env: x.y.z should be able to discover service in env: x
+        serviceNodes = ArrayListMultimap.create();
+        serviceNodes.put(
+                ShardInfo.builder().environment("x").build(),
+                new ServiceNode<>("host3",
+                        9999,
+                        ShardInfo.builder().environment("x").build(),
+                        HealthcheckStatus.healthy,
+                        System.currentTimeMillis(),
+                        "http"));
+        doReturn(serviceNodes).when(serviceRegistry).nodes();
+
+        nodes = selector("x.y.z").nodes(null, serviceRegistry);
+        assertEquals(1, nodes.size());
+        assertEquals("host3", nodes.get(0).getHost());
+        assertEquals(9999, nodes.get(0).getPort());
+
     }
 }


### PR DESCRIPTION
 Fix to ensure all child envs at different levels are available for parent env in shard selector